### PR TITLE
64 battlenetworkdiscovery initial implementation

### DIFF
--- a/Assets/Scripts/BattleNetworkDiscovery.cs
+++ b/Assets/Scripts/BattleNetworkDiscovery.cs
@@ -1,0 +1,31 @@
+using System.Net;
+using System;
+using Mirror.Discovery;
+using UnityEngine;
+
+public class BattleNetworkDiscovery : NetworkDiscoveryBase<BattleServerRequest, BattleServerResponse> {
+    protected override BattleServerResponse ProcessRequest(BattleServerRequest request, IPEndPoint endpoint) {
+        try {
+            return new BattleServerResponse {
+                serverId = ServerId,
+                uri = transport.ServerUri()
+            };
+        } catch (NotImplementedException) {
+            Debug.LogError($"Transport {transport} does not support network discovery");
+            throw;
+        }
+    }
+    
+    protected override BattleServerRequest GetRequest() => new BattleServerRequest();
+
+    protected override void ProcessResponse(BattleServerResponse response, IPEndPoint endpoint) {
+        response.EndPoint = endpoint;
+
+        UriBuilder realUri = new UriBuilder(response.uri) {
+            Host = response.EndPoint.Address.ToString()
+        };
+        response.uri = realUri.Uri;
+
+        OnServerFound.Invoke(response);
+    }
+}

--- a/Assets/Scripts/BattleNetworkDiscovery.cs.meta
+++ b/Assets/Scripts/BattleNetworkDiscovery.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 61bb565342a1a994f869b1f9aa31849a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/BattleServerRequest.cs
+++ b/Assets/Scripts/BattleServerRequest.cs
@@ -1,0 +1,5 @@
+using Mirror;
+
+public struct BattleServerRequest : NetworkMessage {
+
+}

--- a/Assets/Scripts/BattleServerRequest.cs.meta
+++ b/Assets/Scripts/BattleServerRequest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bb59d520598e1d5479e2af14a79a7a3b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/BattleServerResponse.cs
+++ b/Assets/Scripts/BattleServerResponse.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Net;
+using Mirror;
+
+public struct BattleServerResponse : NetworkMessage {
+    public IPEndPoint EndPoint { get; set; }
+
+    public Uri uri;
+
+    public long serverId;
+}

--- a/Assets/Scripts/BattleServerResponse.cs.meta
+++ b/Assets/Scripts/BattleServerResponse.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ea73995c476fbed4c981d052a4321d53
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Since NetworkDiscovery is a class that only implements request and response processing, the implementation of BattleNetworkDiscovery is identical to NetworkDiscovery unless additional information is added to be processed.