### PR TITLE
69 qualia intensity implementation

### DIFF
--- a/Assets/Scripts/QualiaIntensity.cs
+++ b/Assets/Scripts/QualiaIntensity.cs
@@ -1,6 +1,14 @@
 using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 
 internal sealed class QualiaIntensity {
+    private enum IntensityUpdatePattern {
+        Discreate,
+        Continuous,
+    }
+
     internal event Action OnIntensityRateReached000Discretely;
     internal event Action OnIntensityRateReached025Discretely;
     internal event Action OnIntensityRateReached050Discretely;
@@ -29,10 +37,29 @@ internal sealed class QualiaIntensity {
     internal event Action OnIntensityRateThrough050DownwardContinuously;
     internal event Action OnIntensityRateThrough075DownwardContinuously;
 
+    internal static int _updateTimesPerSecond;
+
+    internal static int UpdateTimesPerSecond {
+        get {
+            return _updateTimesPerSecond;
+        }
+        set {
+            _updateTimesPerSecond = value;
+        }
+    }
+
+    static QualiaIntensity() {
+        _updateTimesPerSecond = 60;
+    }
+
     private readonly float _minIntensity;
     private readonly float _maxIntensity;
 
+    private readonly List<CancellationTokenSource> _updateScheduleCtsList;
+
     private float _intensity;
+
+    private CancellationTokenSource _autoRecoveryCts;
 
     internal float Intensity {
         get {
@@ -49,7 +76,76 @@ internal sealed class QualiaIntensity {
         }
     }
 
+    internal QualiaIntensity(float minIntensity, float maxIntensity, float intensity) {
+        _minIntensity = minIntensity;
+        _maxIntensity = maxIntensity;
+
+        _updateScheduleCtsList = new List<CancellationTokenSource>();
+
+        _intensity = intensity;
+    }
+
+    ~QualiaIntensity() {
+        foreach (var updateScheduleCts in  _updateScheduleCtsList) {
+            updateScheduleCts.Cancel();
+            updateScheduleCts.Dispose();
+        }
+
+        if (_autoRecoveryCts != null) {
+            _autoRecoveryCts.Cancel();
+            _autoRecoveryCts.Dispose();
+        }
+    }
+
     internal void IncreaseImmediately(float amount) {
+        IncreasePatternChecked(amount, IntensityUpdatePattern.Discreate);
+    }
+
+    internal void DecreaseImmediately(float amount) {
+        DecreasePatternChecked(amount, IntensityUpdatePattern.Discreate);
+    }
+
+    internal void IncreaseScheduled(float amount, float timeToReach) {
+        var updateScheduleCts = new CancellationTokenSource();
+        
+        _updateScheduleCtsList.Add(updateScheduleCts);
+
+        _ = Task.Run(() => IncreaseScheduledAsync(amount, timeToReach), updateScheduleCts.Token);
+        updateScheduleCts.Dispose();
+
+        _updateScheduleCtsList.Remove(updateScheduleCts);
+    }
+
+    internal void DecreaseScheduled(float amount, float timeToReach) {
+        var updateScheduleCts = new CancellationTokenSource();
+
+        _updateScheduleCtsList.Add(updateScheduleCts);
+
+        _ = Task.Run(() => DecreaseScheduledAsync(amount, timeToReach), updateScheduleCts.Token);
+
+        _updateScheduleCtsList.Remove(updateScheduleCts);
+    }
+
+    internal void EnableAutoRecovery(float amountPerSecond) {
+        if (_autoRecoveryCts != null) {
+            return;
+        }
+
+        _autoRecoveryCts = new CancellationTokenSource();
+        _ = Task.Run(() => EnableAutoRecoveryAsync(amountPerSecond), _autoRecoveryCts.Token);
+    }
+
+    internal void DisableAutoRecovery() {
+        if (_autoRecoveryCts == null) {
+            return;
+        }
+
+        _autoRecoveryCts.Cancel();
+        _autoRecoveryCts.Dispose();
+        _autoRecoveryCts = null;
+    }
+
+    private void IncreasePatternChecked(float amount, IntensityUpdatePattern pattern) {
         float intensityRateCache = IntensityRate;
 
         float intensityUpdated = _intensity + amount;
@@ -60,24 +156,45 @@ internal sealed class QualiaIntensity {
 
         float intensityRateUpdated = IntensityRate;
 
-        if (intensityRateCache < 0.25f && intensityRateUpdated >= 0.25f) {
-            OnIntensityRateReached025Discretely();
-            OnIntensityRateThrough025UpwardDiscretely();
-        }
-        if (intensityRateCache < 0.5f && intensityRateUpdated >= 0.5f) {
-            OnIntensityRateReached050Discretely();
-            OnIntensityRateThrough050UpwardDiscretely();
-        }
-        if (intensityRateCache < 0.75f && intensityRateUpdated >= 0.75f) {
-            OnIntensityRateReached075Discretely();
-            OnIntensityRateThrough075UpwardDiscretely();
-        }
-        if (intensityRateCache < 1f && intensityRateUpdated == 1f) {
-            OnIntensityRateReached100Discretely();
+        switch (pattern) {
+            case IntensityUpdatePattern.Discreate:
+                if (intensityRateCache < 0.25f && intensityRateUpdated >= 0.25f) {
+                    OnIntensityRateReached025Discretely();
+                    OnIntensityRateThrough025UpwardDiscretely();
+                }
+                if (intensityRateCache < 0.5f && intensityRateUpdated >= 0.5f) {
+                    OnIntensityRateReached050Discretely();
+                    OnIntensityRateThrough050UpwardDiscretely();
+                }
+                if (intensityRateCache < 0.75f && intensityRateUpdated >= 0.75f) {
+                    OnIntensityRateReached075Discretely();
+                    OnIntensityRateThrough075UpwardDiscretely();
+                }
+                if (intensityRateCache < 1f && intensityRateUpdated == 1f) {
+                    OnIntensityRateReached100Discretely();
+                }
+                break;
+            case IntensityUpdatePattern.Continuous:
+                if (intensityRateCache < 0.25f && intensityRateUpdated >= 0.25f) {
+                    OnIntensityRateReached025Continuously();
+                    OnIntensityRateThrough025UpwardContinuously();
+                }
+                if (intensityRateCache < 0.5f && intensityRateUpdated >= 0.5f) {
+                    OnIntensityRateReached050Continuously();
+                    OnIntensityRateThrough050UpwardContinuously();
+                }
+                if (intensityRateCache < 0.75f && intensityRateUpdated >= 0.75f) {
+                    OnIntensityRateReached075Continuously();
+                    OnIntensityRateThrough075UpwardContinuously();
+                }
+                if (intensityRateCache < 1f && intensityRateUpdated == 1f) {
+                    OnIntensityRateReached100Continuously();
+                }
+                break;
         }
     }
 
-    internal void DecreaseImmediately(float amount) {
+    private void DecreasePatternChecked(float amount, IntensityUpdatePattern pattern) {
         float intensityRateCache = IntensityRate;
 
         float intensityUpdated = _intensity - amount;
@@ -88,36 +205,86 @@ internal sealed class QualiaIntensity {
 
         float intensityRateUpdated = IntensityRate;
 
-        if (intensityRateCache > 0.75f && intensityRateUpdated <= 0.75f) {
-            OnIntensityRateReached075Discretely();
-            OnIntensityRateThrough075DownwardDiscretely();
-        }
-        if (intensityRateCache > 0.5f && intensityRateUpdated <= 0.5f) {
-            OnIntensityRateReached050Discretely();
-            OnIntensityRateThrough050DownwardDiscretely();
-        }
-        if (intensityRateCache > 0.25f && intensityRateUpdated <= 0.25f) {
-            OnIntensityRateReached025Discretely();
-            OnIntensityRateThrough025DownwardDiscretely();
-        }
-        if (intensityRateCache > 0f && intensityRateUpdated == 0f) {
-            OnIntensityRateReached100Discretely();
+        switch (pattern) {
+            case IntensityUpdatePattern.Discreate:
+                if (intensityRateCache > 0.75f && intensityRateUpdated <= 0.75f) {
+                    OnIntensityRateReached075Discretely();
+                    OnIntensityRateThrough075DownwardDiscretely();
+                }
+                if (intensityRateCache > 0.5f && intensityRateUpdated <= 0.5f) {
+                    OnIntensityRateReached050Discretely();
+                    OnIntensityRateThrough050DownwardDiscretely();
+                }
+                if (intensityRateCache > 0.25f && intensityRateUpdated <= 0.25f) {
+                    OnIntensityRateReached025Discretely();
+                    OnIntensityRateThrough025DownwardDiscretely();
+                }
+                if (intensityRateCache > 0f && intensityRateUpdated == 0f) {
+                    OnIntensityRateReached000Discretely();
+                }
+                break;
+            case IntensityUpdatePattern.Continuous:
+                if (intensityRateCache > 0.75f && intensityRateUpdated <= 0.75f) {
+                    OnIntensityRateReached075Continuously();
+                    OnIntensityRateThrough075DownwardContinuously();
+                }
+                if (intensityRateCache > 0.5f && intensityRateUpdated <= 0.5f) {
+                    OnIntensityRateReached050Continuously();
+                    OnIntensityRateThrough050DownwardContinuously();
+                }
+                if (intensityRateCache > 0.25f && intensityRateUpdated <= 0.25f) {
+                    OnIntensityRateReached025Continuously();
+                    OnIntensityRateThrough025DownwardContinuously();
+                }
+                if (intensityRateCache > 0f && intensityRateUpdated == 0f) {
+                    OnIntensityRateReached000Continuously();
+                }
+                break;
         }
     }
 
-    internal void IncreaseScheduled(float amount, float timeToReach) {
+    private async void IncreaseScheduledAsync(float amount, float timeToReach) {
+        int totalIncreaseCount = (int)(timeToReach * _updateTimesPerSecond);
 
+        int secondToMillisecond = 1000;
+        int increaseInterval = (int)(1f / _updateTimesPerSecond * secondToMillisecond);
+
+        float amountPerSecond = amount / timeToReach;
+        float amountPerUpdate = amountPerSecond / _updateTimesPerSecond;
+
+        for (int increaseCount = 0; increaseCount < totalIncreaseCount; increaseCount++) {
+            IncreasePatternChecked(amountPerUpdate, IntensityUpdatePattern.Continuous);
+
+            await Task.Delay(increaseInterval);
+        }
     }
 
-    internal void DecreaseScheduled(float amount, float timeToReach) {
+    private async void DecreaseScheduledAsync(float amount, float timeToReach) {
+        int totalDecreaseCount = (int)(timeToReach * _updateTimesPerSecond);
 
+        int secondToMillisecond = 1000;
+        int decreaseInterval = (int)(1f / _updateTimesPerSecond * secondToMillisecond);
+
+        float amountPerSecond = amount / timeToReach;
+        float amountPerUpdate = amountPerSecond / _updateTimesPerSecond;
+
+        for (int decreaseCount = 0; decreaseCount < totalDecreaseCount; decreaseCount++) {
+            DecreasePatternChecked(amountPerUpdate, IntensityUpdatePattern.Continuous);
+
+            await Task.Delay(decreaseInterval);
+        }
     }
 
-    internal void EnableAutoRecovery() {
+    private async void EnableAutoRecoveryAsync(float amountPerSecond) {
+        int secondToMillisecond = 1000;
+        int increaseInterval = (int)(1f / _updateTimesPerSecond * secondToMillisecond);
 
-    }
+        float amountPerUpdate = amountPerSecond / _updateTimesPerSecond;
 
-    internal void DisableAutoRecovery() {
+        while (true) {
+            IncreasePatternChecked(amountPerUpdate, IntensityUpdatePattern.Continuous);
 
+            await Task.Delay(increaseInterval);
+        }
     }
 }

--- a/Assets/Scripts/QualiaIntensity.cs
+++ b/Assets/Scripts/QualiaIntensity.cs
@@ -1,0 +1,123 @@
+using System;
+
+internal sealed class QualiaIntensity {
+    internal event Action OnIntensityRateReached000Discretely;
+    internal event Action OnIntensityRateReached025Discretely;
+    internal event Action OnIntensityRateReached050Discretely;
+    internal event Action OnIntensityRateReached075Discretely;
+    internal event Action OnIntensityRateReached100Discretely;
+
+    internal event Action OnIntensityRateThrough025UpwardDiscretely;
+    internal event Action OnIntensityRateThrough050UpwardDiscretely;
+    internal event Action OnIntensityRateThrough075UpwardDiscretely;
+
+    internal event Action OnIntensityRateThrough025DownwardDiscretely;
+    internal event Action OnIntensityRateThrough050DownwardDiscretely;
+    internal event Action OnIntensityRateThrough075DownwardDiscretely;
+
+    internal event Action OnIntensityRateReached000Continuously;
+    internal event Action OnIntensityRateReached025Continuously;
+    internal event Action OnIntensityRateReached050Continuously;
+    internal event Action OnIntensityRateReached075Continuously;
+    internal event Action OnIntensityRateReached100Continuously;
+
+    internal event Action OnIntensityRateThrough025UpwardContinuously;
+    internal event Action OnIntensityRateThrough050UpwardContinuously;
+    internal event Action OnIntensityRateThrough075UpwardContinuously;
+
+    internal event Action OnIntensityRateThrough025DownwardContinuously;
+    internal event Action OnIntensityRateThrough050DownwardContinuously;
+    internal event Action OnIntensityRateThrough075DownwardContinuously;
+
+    private readonly float _minIntensity;
+    private readonly float _maxIntensity;
+
+    private float _intensity;
+
+    internal float Intensity {
+        get {
+            return _intensity;
+        }
+    }
+
+    internal float IntensityRate {
+        get {
+            float maxIntensityRange = _maxIntensity - _minIntensity;
+            float intensityRange = _intensity - _minIntensity;
+            float intensityRate = intensityRange / maxIntensityRange;
+            return intensityRate;
+        }
+    }
+
+    internal void IncreaseImmediately(float amount) {
+        float intensityRateCache = IntensityRate;
+
+        float intensityUpdated = _intensity + amount;
+        if (intensityUpdated > _maxIntensity) {
+            intensityUpdated = _maxIntensity;
+        }
+        _intensity = intensityUpdated;
+
+        float intensityRateUpdated = IntensityRate;
+
+        if (intensityRateCache < 0.25f && intensityRateUpdated >= 0.25f) {
+            OnIntensityRateReached025Discretely();
+            OnIntensityRateThrough025UpwardDiscretely();
+        }
+        if (intensityRateCache < 0.5f && intensityRateUpdated >= 0.5f) {
+            OnIntensityRateReached050Discretely();
+            OnIntensityRateThrough050UpwardDiscretely();
+        }
+        if (intensityRateCache < 0.75f && intensityRateUpdated >= 0.75f) {
+            OnIntensityRateReached075Discretely();
+            OnIntensityRateThrough075UpwardDiscretely();
+        }
+        if (intensityRateCache < 1f && intensityRateUpdated == 1f) {
+            OnIntensityRateReached100Discretely();
+        }
+    }
+
+    internal void DecreaseImmediately(float amount) {
+        float intensityRateCache = IntensityRate;
+
+        float intensityUpdated = _intensity - amount;
+        if (intensityUpdated < _minIntensity) {
+            intensityUpdated = _minIntensity;
+        }
+        _intensity = intensityUpdated;
+
+        float intensityRateUpdated = IntensityRate;
+
+        if (intensityRateCache > 0.75f && intensityRateUpdated <= 0.75f) {
+            OnIntensityRateReached075Discretely();
+            OnIntensityRateThrough075DownwardDiscretely();
+        }
+        if (intensityRateCache > 0.5f && intensityRateUpdated <= 0.5f) {
+            OnIntensityRateReached050Discretely();
+            OnIntensityRateThrough050DownwardDiscretely();
+        }
+        if (intensityRateCache > 0.25f && intensityRateUpdated <= 0.25f) {
+            OnIntensityRateReached025Discretely();
+            OnIntensityRateThrough025DownwardDiscretely();
+        }
+        if (intensityRateCache > 0f && intensityRateUpdated == 0f) {
+            OnIntensityRateReached100Discretely();
+        }
+    }
+
+    internal void IncreaseScheduled(float amount, float timeToReach) {
+
+    }
+
+    internal void DecreaseScheduled(float amount, float timeToReach) {
+
+    }
+
+    internal void EnableAutoRecovery() {
+
+    }
+
+    internal void DisableAutoRecovery() {
+
+    }
+}

--- a/Assets/Scripts/QualiaIntensity.cs
+++ b/Assets/Scripts/QualiaIntensity.cs
@@ -4,8 +4,9 @@ using System.Threading;
 using System.Threading.Tasks;
 
 internal sealed class QualiaIntensity {
+    // Corrected the typo.
     private enum IntensityUpdatePattern {
-        Discreate,
+        Discrete,
         Continuous,
     }
 
@@ -98,11 +99,11 @@ internal sealed class QualiaIntensity {
     }
 
     internal void IncreaseImmediately(float amount) {
-        IncreasePatternChecked(amount, IntensityUpdatePattern.Discreate);
+        IncreasePatternChecked(amount, IntensityUpdatePattern.Discrete);
     }
 
     internal void DecreaseImmediately(float amount) {
-        DecreasePatternChecked(amount, IntensityUpdatePattern.Discreate);
+        DecreasePatternChecked(amount, IntensityUpdatePattern.Discrete);
     }
 
     internal void IncreaseScheduled(float amount, float timeToReach) {
@@ -157,7 +158,7 @@ internal sealed class QualiaIntensity {
         float intensityRateUpdated = IntensityRate;
 
         switch (pattern) {
-            case IntensityUpdatePattern.Discreate:
+            case IntensityUpdatePattern.Discrete:
                 if (intensityRateCache < 0.25f && intensityRateUpdated >= 0.25f) {
                     OnIntensityRateReached025Discretely();
                     OnIntensityRateThrough025UpwardDiscretely();
@@ -206,7 +207,7 @@ internal sealed class QualiaIntensity {
         float intensityRateUpdated = IntensityRate;
 
         switch (pattern) {
-            case IntensityUpdatePattern.Discreate:
+            case IntensityUpdatePattern.Discrete:
                 if (intensityRateCache > 0.75f && intensityRateUpdated <= 0.75f) {
                     OnIntensityRateReached075Discretely();
                     OnIntensityRateThrough075DownwardDiscretely();
@@ -257,6 +258,11 @@ internal sealed class QualiaIntensity {
 
             await Task.Delay(increaseInterval);
         }
+
+        // Error compensation.
+        float totalIncreaseCountDecimalPortion = timeToReach * _updateTimesPerSecond - totalIncreaseCount;
+        float errorCompensation = amountPerUpdate * totalIncreaseCountDecimalPortion;
+        IncreasePatternChecked(errorCompensation, IntensityUpdatePattern.Continuous);
     }
 
     private async void DecreaseScheduledAsync(float amount, float timeToReach) {
@@ -273,6 +279,11 @@ internal sealed class QualiaIntensity {
 
             await Task.Delay(decreaseInterval);
         }
+
+        // Error compensation.
+        float totalDecreaseCountDecimalPortion = timeToReach * _updateTimesPerSecond - totalDecreaseCount;
+        float errorCompensation = amountPerUpdate * totalDecreaseCountDecimalPortion;
+        DecreasePatternChecked(errorCompensation, IntensityUpdatePattern.Continuous);
     }
 
     private async void EnableAutoRecoveryAsync(float amountPerSecond) {

--- a/Assets/Scripts/QualiaIntensity.cs.meta
+++ b/Assets/Scripts/QualiaIntensity.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e1c124162392e494c8c2a313e6aeac33
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
「クオリア強度」はゲーム内でアニマを描ける残量のことです。
UIに非依存な実装をするために、残量の増減を細かく指定する機能、及び残量に対してイベントを設定できるようにしました。
実装した機能は以下の通りです。
- 指定量だけ増やす、減らす機能(アイテムやデバフなどによってゲージが瞬間的に増減する時に使用)
- ゆっくりと回復、消耗する機能(同じくアイテムやデバフの使用を想定)
- 自動回復

"Qualia Intensity" is a remaining which shows the capacity of drawing animas.
To accomplish the implementation independent of UI, I implemented features to designate increase/decrease in detail and to enable programmers to subscribe event depending on the amount of remaining.
Features I implemented are below:
- Ability to increase or decrease by a specified amount (used when the gauge is momentarily increased or decreased by items, debuffs, etc.)
- A function that slowly recovers or depletes (also assumes the use of items or debuffs)
- Automatic recovery